### PR TITLE
Fixed error in rendered normal maps: gamma correction turned off

### DIFF
--- a/render_blender.py
+++ b/render_blender.py
@@ -57,6 +57,8 @@ scene.view_layers["View Layer"].use_pass_normal = True
 scene.view_layers["View Layer"].use_pass_diffuse_color = True
 scene.view_layers["View Layer"].use_pass_object_index = True
 
+scene.view_settings.view_transform = 'Raw'
+
 nodes = bpy.context.scene.node_tree.nodes
 links = bpy.context.scene.node_tree.links
 
@@ -196,7 +198,7 @@ bpy.data.objects['Sun'].rotation_euler[0] += 180
 
 # Place camera
 cam = scene.objects['Camera']
-cam.location = (0, 1, 0.6)
+cam.location = (5, 6, 5.6)
 cam.data.lens = 35
 cam.data.sensor_width = 32
 


### PR DESCRIPTION
Blender by default performs gamma-correction for all images. It ruins normal maps (at least, they are not unit-length, but usually scaled and distorted). 

Simple fix:
```
scene.view_settings.view_transform = 'Raw'
```

Comparison:  
**Before**
![_r_000_normal0001](https://user-images.githubusercontent.com/49251289/162855660-76fc2c55-a9bd-4b0c-b25a-4419d6b38431.png)

**After**
![_r_000_normal0001](https://user-images.githubusercontent.com/49251289/162855719-e977d798-8a3c-471f-9952-49c02d45cabf.png)
